### PR TITLE
Openshift- Use secrets for username/password for both existing MQ/DB, license and keystore files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Helm Charts for Digital.ai Deploy Changelog
 All changes to this chart will be documented in this file
 
+## [1.1.2]
+* Use secrets for username/password for both existing MQ/DB, license and keystore files
+
 ## [1.1.1]
 * Add support for XL-Satellite
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v9.7
 description: A Helm chart for XL Deploy
 name: xl-deploy-oc-helmcharts
-version: 1.1.1-alpha
+version: 1.1.2-alpha
 
 dependencies:
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,17 +1,18 @@
 ## To get the application URL, run:
-{{- if .Values.route.Enabled }}
-{{- range .Values.route.hosts }}
-http{{ if $.Values.route.tls }}s{{ end }}://{{ . }}{{ $.Values.route.path }}
-{{- end }}
+{{- range .Values.ingress.hosts }}
+http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
 
 ## To get the admin password for xl-deploy, run:
 kubectl get secret --namespace {{ .Release.Namespace }} {{ include "xl-deploy.fullname" . }} -o jsonpath="{.data.deploy-password}" | base64 --decode; echo
-{{ if .Values.postgresql.install }}
-## To get the password for postgresql, run
-kubectl get secret {{ .Release.Name }}-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode; echo
+
+{{- if .Values.postgresql.install }}
+## To get the password for postgresql, run:
+kubectl get secret --namespace  {{ .Release.Namespace }} {{ .Release.Name }}-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode; echo
 {{ end }}
-{{- if index .Values "rabbitmq" "install" }}
-## To get the password for rabbitMQ, run
-kubectl get secret {{ .Release.Name }}-rabbitmq  -o jsonpath="{.data.rabbitmq-password}" | base64 --decode; echo
+## To get the password for rabbitMQ, run:
+{{- if .Values.rabbitmq.install }}
+kubectl get secret --namespace  {{ .Release.Namespace }} {{ .Release.Name }}-rabbitmq   -o jsonpath="{.data.rabbitmq-password}" | base64 --decode; echo
+{{- else }}
+kubectl get secret --namespace {{ .Release.Namespace }} {{ include "xl-deploy.fullname" . }} -o jsonpath="{.data.rabbitmqPassword}" | base64 --decode; echo
 {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,6 +1,8 @@
 ## To get the application URL, run:
-{{- range .Values.ingress.hosts }}
-http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- if .Values.route.Enabled }}
+{{- range .Values.route.hosts }}
+http{{ if $.Values.route.tls }}s{{ end }}://{{ . }}{{ $.Values.route.path }}
+{{- end }}
 {{- end }}
 
 ## To get the admin password for xl-deploy, run:

--- a/templates/scc.yaml
+++ b/templates/scc.yaml
@@ -33,7 +33,7 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ template "xl-deploy.name" . }}-sa
 volumes:
 - '*'
-{{- if index .Values "rabbitmq" "install" }}
+{{- if .Values.rabbitmq.install }}
 ---
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -14,3 +14,20 @@ data:
   {{ else }}
   deploy-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
+  {{ if .Values.xldLicense }}
+  xld-License: {{ .Values.xldLicense | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.RepositoryKeystore }}
+  repositoryKeystore: {{ .Values.RepositoryKeystore | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.KeystorePassphrase }}
+  keystorePassphrase: {{ .Values.KeystorePassphrase | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.UseExistingDB.Enabled }}
+  databaseUsername: {{ .Values.UseExistingDB.XL_DB_USERNAME | b64enc | quote }}
+  databasePassword: {{ .Values.UseExistingDB.XL_DB_PASSWORD | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.UseExistingMQ.Enabled }}
+  rabbitmqUsername: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_USERNAME | b64enc | quote }}
+  rabbitmqPassword: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_PASSWORD | b64enc | quote }}
+  {{ end }}

--- a/templates/xl-deploy-master.yaml
+++ b/templates/xl-deploy-master.yaml
@@ -104,13 +104,22 @@ spec:
             - name: XL_DB_URL
               value: {{.Values.UseExistingDB.XL_DB_URL | quote}}
             - name: XL_DB_USERNAME
-              value: {{.Values.UseExistingDB.XL_DB_USERNAME}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: databaseUsername 
             - name: XL_DB_PASSWORD
-              value: {{.Values.UseExistingDB.XL_DB_PASSWORD | quote}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: databasePassword
             {{- end }}
             {{- end }}
             - name: XL_LICENSE
-              value: "{{ .Values.xldLicense }}"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: xld-License
             - name: XL_METRICS_ENABLED
               value: "false"
             - name: FORCE_UPGRADE
@@ -134,9 +143,15 @@ spec:
             {{- else }}
             {{- if .Values.UseExistingMQ.Enabled }}
             - name: XLD_TASK_QUEUE_USERNAME
-              value: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_USERNAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: rabbitmqUsername
             - name: XLD_TASK_QUEUE_PASSWORD
-              value: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_PASSWORD | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: rabbitmqPassword
             - name: XLD_TASK_QUEUE_URL
               value: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_URL | quote }}
             - name: XLD_TASK_QUEUE_DRIVER_CLASS_NAME
@@ -144,9 +159,15 @@ spec:
             {{- end }}
             {{- end }}
             - name: REPOSITORY_KEYSTORE
-              value: {{ .Values.RepositoryKeystore }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: repositoryKeystore
             - name: REPOSITORY_KEYSTORE_PASSPHRASE
-              value: {{ .Values.KeystorePassphrase }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: keystorePassphrase
             {{- if .Values.satellite.Enabled }}
             - name: ENABLE_SATELLITE
               value: {{ .Values.satellite.Enabled | quote }}

--- a/templates/xl-deploy-master.yaml
+++ b/templates/xl-deploy-master.yaml
@@ -128,9 +128,9 @@ spec:
               value: "false"
             - name: HOSTNAME_SUFFIX
               value: ".{{ template "xl-deploy.fullname" . }}-master.{{.Release.Namespace}}.svc.cluster.local"
-            {{- if index .Values "rabbitmq" "install" }}
+            {{- if .Values.rabbitmq.install }}
             - name: XLD_TASK_QUEUE_USERNAME
-              value: {{ index .Values "rabbitmq" "rabbitmqUsername" }}
+              value: {{ .Values.rabbitmq.auth.username }}
             - name: XLD_TASK_QUEUE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/templates/xl-deploy-worker.yaml
+++ b/templates/xl-deploy-worker.yaml
@@ -93,13 +93,22 @@ spec:
             - name: XL_DB_URL
               value: {{.Values.UseExistingDB.XL_DB_URL | quote}}
             - name: XL_DB_USERNAME
-              value: {{.Values.UseExistingDB.XL_DB_USERNAME}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: databaseUsername
             - name: XL_DB_PASSWORD
-              value: {{.Values.UseExistingDB.XL_DB_PASSWORD | quote}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: databasePassword
             {{- end }}
             {{- end }}
             - name: XL_LICENSE
-              value: "{{ .Values.xldLicense }}"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: xld-License
             - name: XL_METRICS_ENABLED
               value: "false"
             - name: FORCE_UPGRADE
@@ -123,9 +132,15 @@ spec:
             {{- else }}
             {{- if .Values.UseExistingMQ.Enabled }}
             - name: XLD_TASK_QUEUE_USERNAME
-              value: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_USERNAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: rabbitmqUsername
             - name: XLD_TASK_QUEUE_PASSWORD
-              value: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_PASSWORD | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: rabbitmqPassword
             - name: XLD_TASK_QUEUE_URL
               value: {{ .Values.UseExistingMQ.XLD_TASK_QUEUE_URL | quote }}
             - name: XLD_TASK_QUEUE_DRIVER_CLASS_NAME
@@ -133,9 +148,15 @@ spec:
             {{- end }}
             {{- end }}
             - name: REPOSITORY_KEYSTORE
-              value: {{ .Values.RepositoryKeystore }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: repositoryKeystore
             - name: REPOSITORY_KEYSTORE_PASSPHRASE
-              value: {{ .Values.KeystorePassphrase }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-deploy.fullname" . }}
+                  key: keystorePassphrase
             {{- if .Values.satellite.Enabled }}
             - name: ENABLE_SATELLITE
               value: {{ .Values.satellite.Enabled | quote }}

--- a/templates/xl-deploy-worker.yaml
+++ b/templates/xl-deploy-worker.yaml
@@ -117,9 +117,9 @@ spec:
               value: "false"
             - name: HOSTNAME_SUFFIX
               value: ".{{ template "xl-deploy.name" . }}"
-            {{- if index .Values "rabbitmq" "install" }}
+            {{- if .Values.rabbitmq.install }}
             - name: XLD_TASK_QUEUE_USERNAME
-              value: {{ index .Values "rabbitmq" "rabbitmqUsername" }}
+              value: {{ .Values.rabbitmq.auth.username }}
             - name: XLD_TASK_QUEUE_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
1. Secrets are used for Postgres username/password
2. Secrets are used for RabbitMQ username/password
3. Secrets are used for XLR License and KeystorePassphrase



