### PR TITLE
ENG-7206 ENG-8694 make worker connect to master

### DIFF
--- a/templates/xl-deploy-worker.yaml
+++ b/templates/xl-deploy-worker.yaml
@@ -131,8 +131,8 @@ spec:
               value: "false"
             - name: XLD_IN_PROCESS
               value: "false"
-            - name: HOSTNAME_SUFFIX
-              value: ".{{ template "xl-deploy.name" . }}"
+            - name: USE_IP_AS_HOSTNAME
+              value: "true"
             {{- if .Values.rabbitmq.install }}
             - name: XLD_TASK_QUEUE_USERNAME
               value: {{ .Values.rabbitmq.auth.username }}


### PR DESCRIPTION
Remove hostname suffix for worker to connect to master after migrating hostname property to deployit.conf, (becuase of the suffix hash differs and it doesn't connect to master.)